### PR TITLE
feat: MockReplicant fires change event

### DIFF
--- a/src/mock-nodecg.js
+++ b/src/mock-nodecg.js
@@ -60,6 +60,16 @@ class MockReplicant extends EventEmitter {
 	validate() {
 		return true;
 	}
+
+	get value() {
+		return this._value;
+	}
+
+	set value(newValue) {
+		const oldValue = this._value;
+		this._value = newValue;
+		this.emit('change', newValue, oldValue);
+	}
 }
 
 class MockNodeCGLogger {


### PR DESCRIPTION
Implemented rudimentary value operation on mock replicant. Tested on a local project. I also tested real replicants and found that the value was updated before the change event fired, so I did that as well.

The project doesn't have unit tests though, so I couldn't do much more than that. Please give it a look over.